### PR TITLE
[INT-328] write binary to volume

### DIFF
--- a/near/subscription.go
+++ b/near/subscription.go
@@ -55,7 +55,7 @@ func NewSubscription(ctx context.Context, config *Config, events []string) (*Sub
 	}
 
 	// Write binary to file so we can execute it
-	err = os.WriteFile("nakji_near_client", bin, 0755)
+	err = os.WriteFile("/nearclient/nakji_near_client", bin, 0755)
 	if err != nil {
 		log.Fatal().Err(err).Msg("failed to write embedded Nakji Near Client binary to local fs")
 	}
@@ -146,7 +146,7 @@ func (s *Subscription) backfill() {
 func (s *Subscription) startLakeStream(port string, fromBlock uint64, numBlocks uint64) {
 	// Setup command for Lake stream
 	cmd := []string{
-		"./nakji_near_client",
+		"/nearclient/nakji_near_client",
 	}
 
 	cmd = append(cmd, fmt.Sprintf("--port=%s", port))


### PR DESCRIPTION
Fix NEAR crash from trying to write to read only volume by creating a volume for the rust binary and writing to it