### PR TITLE
[INT-468] Documentation Updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,6 @@ go run cmd/<connector_name>/main.go
 ```
 
 ### 🚀 To deploy
-Ensure that the connector's docker image has been built successfully and pushed to the docker repo in either Nakji [Slack](https://blepai.slack.com/archives/C03DL2A73SB) or [Google Artifact Registry](https://console.cloud.google.com/artifacts/docker/blep-core/asia/docker?project=blep-core).
+For Nakji devs, ensure that the image was built successfully (check Github Actions) and pushed to our internal artifact registry, then update Helmfile values.yaml. 
 
-Update Helmfile values.yaml to use the new docker image.
+If you would like to build your own connector, start by taking a look at our [documentation](https://docs.nakji.network/docs/intro), and [reach out to our team](hello@nakji.network) with any questions you may have.

--- a/README.md
+++ b/README.md
@@ -12,4 +12,4 @@ go run cmd/<connector_name>/main.go
 ### 🚀 To deploy
 For Nakji devs, ensure that the image was built successfully (check Github Actions) and pushed to our internal artifact registry, then update Helmfile values.yaml. 
 
-If you would like to build your own connector, start by taking a look at our [documentation](https://docs.nakji.network/docs/intro), and [reach out to our team](hello@nakji.network) with any questions you may have.
+If you would like to build your own connector, start by taking a look at our [documentation](https://docs.nakji.network/docs/intro), and [reach out to our team](mailto:hello@nakji.network) with any questions you may have.

--- a/bitcoin/README.md
+++ b/bitcoin/README.md
@@ -1,25 +1,8 @@
-# Running BTC Connector
+# Nakji Bitcoin Connector
 
-We will need `btcd` installed with the following steps in the command line:
+Bitcoin is an innovative payment network and a new kind of money. Bitcoin uses peer-to-peer technology to operate with no central authority or banks; managing transactions and the issuing of bitcoins is carried out collectively by the network. Bitcoin is open-source; its design is public, nobody owns or controls Bitcoin and everyone can take part. Through many of its unique properties, Bitcoin allows exciting uses that could not be covered by any previous payment system.
 
-    go get github.com/btcsuite/btcd
-    cd $GOPATH/src/github.com/btcsuite/btcd
-    GO111MODULE=on go install -v . ./cmd/...
+Nakji currently indexes the following from Bitcoin:
 
-Make sure that go binaries in your PATH with `export PATH="$HOME/go/bin:$PATH"` and maybe add that to
-bashrc/zshrc.
-
-Once `btcd` is installed, you may run the following commands for the BTC connector to work:
-
-    make start-btcd
-    make start-bitcoin
-
-
-Note that if you see a line like `Catching up indexes from height 181186 to 373507` when starting `btcd`,
-that means the RPC serve for `btcd` has not started yet and will only be started after all blocks have
-been indexed. Once all are indexed, the RPC server will be started and `make start-bitcoin` will be
-able to connect its RPC client to `btcd`.
-
-## Running BTC Connector in Prod
-
-We will need to set `bitcoin.rpc.url` key in analytics-config secret for prod to `"btcd:8334"`.
+* Blocks
+* Transactions

--- a/near/README.md
+++ b/near/README.md
@@ -1,6 +1,6 @@
 # Nakji NEAR Connector
 
-The NEAR protocol is a sharded, proof-of-stake, layer-one blockchain that is simple to use, secure and scalable. The Nakji NEAR Connector makes use of NEAR Lake Framework to parse events in Rust, then passes them to a Nakji connector written in Go using websockets (no RPC involved, other than finding most recent block height).
+The NEAR protocol is a sharded, proof-of-stake, layer-one blockchain that is simple to use, secure and scalable. The Nakji NEAR Connector makes use of NEAR Lake Framework to parse events in Rust, then passes them to a Nakji connector written in Go using websockets.
 
 ## Events
 
@@ -8,46 +8,5 @@ As of now, the Nakji NEAR connector indexes:
 
 * Blocks
 * Transactions
-  
-Note: work is underway to add support for `Receipts` and `ExecutionOutcomes`, with `Receipts`, `Transactions`, and `ExecutionOutcomes` all being separate events with separate tables etc.
-
-## Rust Connector
-
-The Rust portion of the Nakji connector streams data from the NEAR chain using NEAR Lake Framework, transforms this data to Prost types using Nakji's Protobuf representation of NEAR events, serializes the data, and broadcasts it over websockets. I had originally used different endpoints for different events, but fixing issues with routing was taking too long. So now all events are wrapped in one message type.
-
-### Development Environment
-
-It is recommended that devlopers use rustup to initialize their Rust environment. Installing Rust directly with Brew can cause issues with IDE extensions, like rust-analyzer for VS Code. Develop in VS Code for cool features like Rust types auto updating with near.proto, useful errors/suggestions/type info, auto installation of dependencies + more. 
-
-#### Setup
-
-* Install rustup: `brew install rustup`
-* Initialize: `rustup-init`
-* Install rust-analyzer to make your life so much easier
-
-#### Run
-
-* Run for development: `cargo run main.rs`
-* Build for production: `cargo build --release` (binary will be at `target/release/nakji_near_client`)
-* If you want to manually run for local development along with the Go connector, consider commenting out the portion of the connect function in client.go that executes the Rust binary.
-
-### Adding Events
-
-To add events, add to the proto file, create a new file in `src/types`, implement `From` for the necessary NEAR primitives, and implement the `ParseStreamMessage` trait for the generated type to handle `StreamerMessage` that comes from NEAR Lake Framework. Finally, follow the pattern of existing types in `main.rs` to create a `NearHandler` type, create a `NearWsServer`, and handle incoming messages in the main loop using the `handle_streamer_message` function you implemented. Note: In order for the new events to be sent to Kafka, `client.go` will also need to be updated (see below).
-
-### Future Improvements
-
-* Many NEAR types do not implement `Copy` or `Clone`, meaning that events are parsed using a borrowed reference to a `StreamerMessage`. This means that only one event type is parsed at a time. 
-* Backfill is inconsistent with other connectors. Currently, backfill is not separated from other events. 
-* Similarly, the connector supports `from-block` but not `num-blocks`.
-* All events are sent to every client. Adding filtering on the rust side would be nice.
-* Consider integrating into chain?
-
-## Go Connector
-
-The Go portion of the connector is very similar to other connectors, other than `client.go`, which defines ws endpoint and event type mappings, generates ws listeners for each endpoint, and sends events to an event chan. Since all events are received as proto messages and require no filtering, the connector writes events from this chan straight to `EventSink`. 
-
-### Adding Events
-
-Assuming you've already taken care of things on the Rust side, all you need to do is add to the eventTypes map in the `NewConnector` function in `near.go`. A ws listener will automatically be generated. If you are attempting to build a separate connector that uses a subset of NEAR events, just create a new connector with a different map in `NewConnector`. Should you want to filter/manipulate events, consider creating a function that uses events received from `Client.events` before passing them to `EventSink`.
-
+* Receipts
+* ExecutionOutcomes


### PR DESCRIPTION
We recently open-sourced this repo. As part of that process, we are cleaning up things that aren't relevant to external users 🧹

* Remove documentation that is only relevant internally & move to confluence
* Remove links to internal services (slack, gcp projects etc)
* Remove anything else outdated or not helpful
* Replace with resources relevant to external users